### PR TITLE
CLI preproc

### DIFF
--- a/configs/config_example.yml
+++ b/configs/config_example.yml
@@ -17,10 +17,23 @@ files:
 
 
 preprocess:
+  image_dirs: []
+
+  target_dirs: []
+
   channels: ["Retardance", "Phase2D", "Brightfield"]
+  # Strings in filenames that identify the channels
+
   fov: ['C5-Site_0','C5-Site_1']
+  # list of subfolder or position indices that identifies a field-of-view
+  # use 'all' to preprocess all positions
+
   multipage: False
+
   z_slice: 2
+
+  pos_dir: True
+  # whether each position is in a subdirectory (True), or in the same directory (False)
 
 
 patch:

--- a/configs/config_example.yml
+++ b/configs/config_example.yml
@@ -1,0 +1,86 @@
+
+files:
+  raw_dirs: ['/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_input_tstack',
+             '/CompMicro/projects/cardiomyocytes/20200722CM_LowMOI_SPS_Fluor/20200722 CM_LowMOI_SPS/dnm_input_tstack']
+
+  supp_dirs: ['/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_supp_tstack',
+              '/CompMicro/projects/cardiomyocytes/20200722CM_LowMOI_SPS_Fluor/20200722 CM_LowMOI_SPS/dnm_supp_tstack']
+
+  train_dirs: ['/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_train_tstack',
+               '/CompMicro/projects/cardiomyocytes/20200722CM_LowMOI_SPS_Fluor/20200722 CM_LowMOI_SPS/dnm_train_tstack']
+
+  val_dirs: ['/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_train_tstack/val',
+                    '/CompMicro/projects/cardiomyocytes/20200722CM_LowMOI_SPS_Fluor/20200722 CM_LowMOI_SPS/dnm_train_tstack/val']
+
+  weights_dir: '/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_train_tstack/weights'
+  # path to save weights during training, subdirectory of train_dirs
+
+
+preprocess:
+  channels: ["Retardance", "Phase2D", "Brightfield"]
+  fov: ['C5-Site_0','C5-Site_1']
+  multipage: False
+  z_slice: 2
+
+
+patch:
+  channels: [0,1,2]
+  fov: ['C5-Site_0','C5-Site_1']
+  gpus: 1
+  window_size: 256
+  save_fig: False
+  reload: True
+  skip_boundary: False
+
+
+inference:
+  model: 'VQ_VAE_z16'
+  # VQ_VAE_z16 or UNet
+
+  weights: '/gpfs/CompMicro/projects/dynamorph/CellVAE/save_0005_bkp4.pt'
+  # pytorch weight file
+
+  save_output: True
+  # write .jpg results from run_vae.process
+
+  gpus: 1
+  gpu_id: 3
+  fov: ['C5-Site_0','C5-Site_1']
+  channels: [0,1,2]
+  num_classes: 3
+  window_size: 256
+  batch_size: 8
+  num_pred_rnd: 5
+  seg_val_cat: 'mg'
+
+
+training:
+  # model definitions
+  model: 'VQ_VAE_z32'
+  num_inputs: 2
+  num_hiddens: 64
+  num_residual_hiddens: 64
+  num_residual_layers: 2
+  num_embeddings: 512
+
+  # normalization
+  channel_mean: [0.4, 0, 0.5]
+  channel_std: [0.05, 0.05, 0.05]
+
+  w_a: 1
+  w_t: 0.5
+
+  # training parameters
+  commitment_cost: 0.25
+  alpha: 0.002
+  epochs: 5000
+  learning_rate: 0.0001
+  batch_size: 96
+  gpus: True
+  gpu_id: 3
+  shuffle_data: False
+  transform: True
+
+
+  
+

--- a/configs/config_example.yml
+++ b/configs/config_example.yml
@@ -1,20 +1,4 @@
 
-#files:
-#  raw_dirs: ['/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_input_tstack',
-#             '/CompMicro/projects/cardiomyocytes/20200722CM_LowMOI_SPS_Fluor/20200722 CM_LowMOI_SPS/dnm_input_tstack']
-#
-#  supp_dirs: ['/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_supp_tstack',
-#              '/CompMicro/projects/cardiomyocytes/20200722CM_LowMOI_SPS_Fluor/20200722 CM_LowMOI_SPS/dnm_supp_tstack']
-#
-#  train_dirs: ['/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_train_tstack',
-#               '/CompMicro/projects/cardiomyocytes/20200722CM_LowMOI_SPS_Fluor/20200722 CM_LowMOI_SPS/dnm_train_tstack']
-#
-#  val_dirs: ['/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_train_tstack/val',
-#                    '/CompMicro/projects/cardiomyocytes/20200722CM_LowMOI_SPS_Fluor/20200722 CM_LowMOI_SPS/dnm_train_tstack/val']
-#
-#  weights_dir: '/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_train_tstack/weights'
-#  # path to save weights during training, subdirectory of train_dirs
-
 
 preprocess:
   image_dirs: ['/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_input_tstack',
@@ -24,15 +8,19 @@ preprocess:
                 '/CompMicro/projects/cardiomyocytes/20200722CM_LowMOI_SPS_Fluor/20200722 CM_LowMOI_SPS/dnm_supp_tstack']
 
   channels: ["Retardance", "Phase2D", "Brightfield"]
-  # Strings in filenames that identify the channels
+  # list of channels to include.  Resulting array is (phase, retardance, brightfield) = (0, 1, 2) index
 
   fov: ['C5-Site_0','C5-Site_1']
   # list of subfolder or position indices that identifies a field-of-view
-  # use 'all' to preprocess all positions
+  # ex: 'all' to preprocess all positions
+  # ex: ['C5-Site_0', 'C5-Site_1', 'C5-Site_2']
+  # ex: [1, 3, 10, 100]
 
   multipage: False
+  # if images are multipage-tiffs
 
   z_slice: 2
+  # single integer to select the z-plane.  "z###" must exist in file names
 
   pos_dir: True
   # whether each position is in a subdirectory (True), or in the same directory (False)

--- a/configs/config_example.yml
+++ b/configs/config_example.yml
@@ -1,25 +1,27 @@
 
-files:
-  raw_dirs: ['/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_input_tstack',
-             '/CompMicro/projects/cardiomyocytes/20200722CM_LowMOI_SPS_Fluor/20200722 CM_LowMOI_SPS/dnm_input_tstack']
-
-  supp_dirs: ['/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_supp_tstack',
-              '/CompMicro/projects/cardiomyocytes/20200722CM_LowMOI_SPS_Fluor/20200722 CM_LowMOI_SPS/dnm_supp_tstack']
-
-  train_dirs: ['/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_train_tstack',
-               '/CompMicro/projects/cardiomyocytes/20200722CM_LowMOI_SPS_Fluor/20200722 CM_LowMOI_SPS/dnm_train_tstack']
-
-  val_dirs: ['/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_train_tstack/val',
-                    '/CompMicro/projects/cardiomyocytes/20200722CM_LowMOI_SPS_Fluor/20200722 CM_LowMOI_SPS/dnm_train_tstack/val']
-
-  weights_dir: '/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_train_tstack/weights'
-  # path to save weights during training, subdirectory of train_dirs
+#files:
+#  raw_dirs: ['/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_input_tstack',
+#             '/CompMicro/projects/cardiomyocytes/20200722CM_LowMOI_SPS_Fluor/20200722 CM_LowMOI_SPS/dnm_input_tstack']
+#
+#  supp_dirs: ['/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_supp_tstack',
+#              '/CompMicro/projects/cardiomyocytes/20200722CM_LowMOI_SPS_Fluor/20200722 CM_LowMOI_SPS/dnm_supp_tstack']
+#
+#  train_dirs: ['/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_train_tstack',
+#               '/CompMicro/projects/cardiomyocytes/20200722CM_LowMOI_SPS_Fluor/20200722 CM_LowMOI_SPS/dnm_train_tstack']
+#
+#  val_dirs: ['/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_train_tstack/val',
+#                    '/CompMicro/projects/cardiomyocytes/20200722CM_LowMOI_SPS_Fluor/20200722 CM_LowMOI_SPS/dnm_train_tstack/val']
+#
+#  weights_dir: '/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_train_tstack/weights'
+#  # path to save weights during training, subdirectory of train_dirs
 
 
 preprocess:
-  image_dirs: []
+  image_dirs: ['/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_input_tstack',
+               '/CompMicro/projects/cardiomyocytes/20200722CM_LowMOI_SPS_Fluor/20200722 CM_LowMOI_SPS/dnm_input_tstack']
 
-  target_dirs: []
+  target_dirs: ['/CompMicro/projects/cardiomyocytes/200721_CM_Mock_SPS_Fluor/20200721_CM_Mock_SPS/dnm_supp_tstack',
+                '/CompMicro/projects/cardiomyocytes/20200722CM_LowMOI_SPS_Fluor/20200722 CM_LowMOI_SPS/dnm_supp_tstack']
 
   channels: ["Retardance", "Phase2D", "Brightfield"]
   # Strings in filenames that identify the channels
@@ -37,6 +39,9 @@ preprocess:
 
 
 patch:
+  raw_dirs:
+  supp_dirs:
+
   channels: [0,1,2]
   fov: ['C5-Site_0','C5-Site_1']
   gpus: 1
@@ -47,11 +52,13 @@ patch:
 
 
 inference:
+  raw_dirs:
+  supp_dirs:
+  weights: ['/gpfs/CompMicro/projects/dynamorph/CellVAE/save_0005_bkp4.pt']
+  # pytorch weight files
+
   model: 'VQ_VAE_z16'
   # VQ_VAE_z16 or UNet
-
-  weights: '/gpfs/CompMicro/projects/dynamorph/CellVAE/save_0005_bkp4.pt'
-  # pytorch weight file
 
   save_output: True
   # write .jpg results from run_vae.process
@@ -68,6 +75,10 @@ inference:
 
 
 training:
+  raw_dirs:
+  supp_dirs:
+  weights_dirs:
+
   # model definitions
   model: 'VQ_VAE_z32'
   num_inputs: 2

--- a/configs/config_reader.py
+++ b/configs/config_reader.py
@@ -1,0 +1,141 @@
+import yaml
+import logging
+
+
+def log_warning(msg, *args, **kwargs):
+    """Log message with level WARNING."""
+    # import logging
+
+    logging.getLogger(__name__).warning(msg, *args, **kwargs)
+
+
+# to add a new configuration parameter, simply add the string to the appropriate set here
+FILES = {
+    'raw_dirs',
+    'supp_dirs',
+    'train_dirs',
+    'val_dirs',
+    'weights_dir'
+}
+
+PREPROCESS = {
+    'channels',
+    'fov',
+    'multipage',
+    'z_slice'
+}
+
+PATCH = {
+    'channels',
+    'fov',
+    'gpus',
+    'window_size',
+    'save_fig',
+    'reload',
+    'skip_boundary'
+}
+
+INFERENCE = {
+    'model',
+    'weights',
+    'save_output',
+    'gpus',
+    'gpu_id',
+    'fov',
+    'channels',
+    'num_classes',
+    'window_size',
+    'batch_size',
+    'num_pred_rnd',
+    'seg_val_cat'
+}
+
+TRAINING = {
+    'model',
+    'num_inputs',
+    'num_hiddens',
+    'num_residual_hiddens',
+    'num_residual_layers',
+    'num_embeddings',
+
+    'w_a',
+    'w_t',
+    'channel_mean',
+    'channel_std',
+
+    'commitment_cost',
+    'alpha',
+    'epochs',
+    'learning_rate',
+    'batch_size',
+    'gpus',
+    'gpu_id',
+    'shuffle_data',
+    'transform',
+}
+
+
+class Object:
+    pass
+
+
+class YamlReader(Object):
+
+    def __init__(self):
+        self.config = None
+
+        # easy way to assign attributes to each category
+        self.files = Object()
+        self.preprocess = Object()
+        self.patch = Object()
+        self.inference = Object()
+        self.training = Object()
+
+    def read_config(self, yml_config):
+        with open(yml_config, 'r') as f:
+            self.config = yaml.load(f)
+
+            self._parse_files()
+            self._parse_preprocessing()
+            self._parse_patch()
+            self._parse_inference()
+            self._parse_training()
+
+    def _parse_files(self):
+        for key, value in self.config['files'].items():
+            if key in FILES:
+                setattr(self.files, key, value)
+            else:
+                log_warning(f"yaml FILE config field {key} is not recognized")
+
+    def _parse_preprocessing(self):
+        for key, value in self.config['preprocess'].items():
+            if key in PREPROCESS:
+                setattr(self.preprocess, key, value)
+            else:
+                log_warning(f"yaml PREPROCESS config field {key} is not recognized")
+
+    def _parse_patch(self):
+        for key, value in self.config['patch'].items():
+            if key in PATCH:
+                setattr(self.patch, key, value)
+            else:
+                log_warning(f"yaml PATCH config field {key} is not recognized")
+
+    def _parse_inference(self):
+        for key, value in self.config['inference'].items():
+            if key in INFERENCE:
+                setattr(self.inference, key, value)
+            else:
+                log_warning(f"yaml INFERENCE config field {key} is not recognized")
+
+    def _parse_training(self):
+        for key, value in self.config['training'].items():
+            if key in TRAINING:
+                setattr(self.training, key, value)
+            else:
+                log_warning(f"yaml TRAINING config field {key} is not recognized")
+
+
+
+

--- a/configs/config_reader.py
+++ b/configs/config_reader.py
@@ -10,15 +10,17 @@ def log_warning(msg, *args, **kwargs):
 
 
 # to add a new configuration parameter, simply add the string to the appropriate set here
-FILES = {
-    'raw_dirs',
-    'supp_dirs',
-    'train_dirs',
-    'val_dirs',
-    'weights_dir'
-}
+# FILES = {
+#     'raw_dirs',
+#     'supp_dirs',
+#     'train_dirs',
+#     'val_dirs',
+#     'weights_dir'
+# }
 
 PREPROCESS = {
+    'image_dirs',
+    'target_dirs',
     'channels',
     'fov',
     'multipage',
@@ -27,6 +29,8 @@ PREPROCESS = {
 }
 
 PATCH = {
+    'raw_dirs',
+    'supp_dirs',
     'channels',
     'fov',
     'gpus',
@@ -37,6 +41,8 @@ PATCH = {
 }
 
 INFERENCE = {
+    'raw_dirs',
+    'supp_dirs',
     'model',
     'weights',
     'save_output',
@@ -52,6 +58,9 @@ INFERENCE = {
 }
 
 TRAINING = {
+    'raw_dirs',
+    'supp_dirs',
+    'weights_dirs',
     'model',
     'num_inputs',
     'num_hiddens',

--- a/configs/config_reader.py
+++ b/configs/config_reader.py
@@ -22,7 +22,8 @@ PREPROCESS = {
     'channels',
     'fov',
     'multipage',
-    'z_slice'
+    'z_slice',
+    'pos_dir'
 }
 
 PATCH = {

--- a/configs/config_reader.py
+++ b/configs/config_reader.py
@@ -2,12 +2,30 @@ import yaml
 import logging
 
 
-def log_warning(msg, *args, **kwargs):
-    """Log message with level WARNING."""
-    # import logging
+# def log_warning(msg, *args, **kwargs):
+#     """Log message with level WARNING."""
+#     # import logging
+#
+#     logging.getLogger(__name__).warning(msg, *args, **kwargs)
 
-    logging.getLogger(__name__).warning(msg, *args, **kwargs)
 
+# replicate from aicsimageio logging mechanism
+###############################################################################
+
+# modify the logging.ERROR level lower for more info
+# CRITICAL
+# ERROR
+# WARNING
+# INFO
+# DEBUG
+# NOTSET
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(levelname)4s: %(module)s:%(lineno)4s %(asctime)s] %(message)s",
+)
+log = logging.getLogger(__name__)
+
+###############################################################################
 
 # to add a new configuration parameter, simply add the string to the appropriate set here
 # FILES = {
@@ -123,28 +141,28 @@ class YamlReader(Object):
             if key in PREPROCESS:
                 setattr(self.preprocess, key, value)
             else:
-                log_warning(f"yaml PREPROCESS config field {key} is not recognized")
+                log.warning(f"yaml PREPROCESS config field {key} is not recognized")
 
     def _parse_patch(self):
         for key, value in self.config['patch'].items():
             if key in PATCH:
                 setattr(self.patch, key, value)
             else:
-                log_warning(f"yaml PATCH config field {key} is not recognized")
+                log.warning(f"yaml PATCH config field {key} is not recognized")
 
     def _parse_inference(self):
         for key, value in self.config['inference'].items():
             if key in INFERENCE:
                 setattr(self.inference, key, value)
             else:
-                log_warning(f"yaml INFERENCE config field {key} is not recognized")
+                log.warning(f"yaml INFERENCE config field {key} is not recognized")
 
     def _parse_training(self):
         for key, value in self.config['training'].items():
             if key in TRAINING:
                 setattr(self.training, key, value)
             else:
-                log_warning(f"yaml TRAINING config field {key} is not recognized")
+                log.warning(f"yaml TRAINING config field {key} is not recognized")
 
 
 

--- a/configs/config_reader.py
+++ b/configs/config_reader.py
@@ -95,7 +95,7 @@ class YamlReader(Object):
         self.config = None
 
         # easy way to assign attributes to each category
-        self.files = Object()
+        # self.files = Object()
         self.preprocess = Object()
         self.patch = Object()
         self.inference = Object()
@@ -105,18 +105,18 @@ class YamlReader(Object):
         with open(yml_config, 'r') as f:
             self.config = yaml.load(f)
 
-            self._parse_files()
+            # self._parse_files()
             self._parse_preprocessing()
             self._parse_patch()
             self._parse_inference()
             self._parse_training()
 
-    def _parse_files(self):
-        for key, value in self.config['files'].items():
-            if key in FILES:
-                setattr(self.files, key, value)
-            else:
-                log_warning(f"yaml FILE config field {key} is not recognized")
+    # def _parse_files(self):
+    #     for key, value in self.config['files'].items():
+    #         if key in FILES:
+    #             setattr(self.files, key, value)
+    #         else:
+    #             log_warning(f"yaml FILE config field {key} is not recognized")
 
     def _parse_preprocessing(self):
         for key, value in self.config['preprocess'].items():

--- a/pipeline/preprocess.py
+++ b/pipeline/preprocess.py
@@ -3,10 +3,14 @@
 import numpy as np
 import cv2
 import os
+import tifffile as tf
+
 
 def load_raw(path: str, 
-             site: str, 
-             multipage: bool = True):
+             site: str,
+             chans: list,
+             multipage: bool = True,
+             z_slice: int = 2):
     """Raw data loader
 
     This function takes a path to an experiment folder and 
@@ -28,32 +32,59 @@ def load_raw(path: str,
         np.array: numpy array as described above
 
     """
+    fullpath = os.path.join(path, site)
+    shapes = []
+
     if not multipage:
-        raise NotImplementedError("loading non-stabilized, non-multipage tiffs not supported")
+        # load singlepage tiffs.  String parse assuming time series and z### format
+        for chan in chans:
+            files = [c for c in os.listdir(fullpath) if chan in c and f"z{z_slice:03d}" in c]
+            files = sorted(files)
+            if "Phase" in chan:
+                phase = np.stack([tf.imread(os.path.join(fullpath, f)) for f in files])
+                shapes.append(phase.shape)
+            if "Retardance" in chan:
+                ret = np.stack([tf.imread(os.path.join(fullpath, f)) for f in files])
+                shapes.append(ret.shape)
+            if "Brightfield" in chan:
+                bf = np.stack([tf.imread(os.path.join(fullpath, f)) for f in files])
+                shapes.append(bf.shape)
 
-    fullpath = path+'/'+site
+    else:
+        # load stabilized multipage tiffs.
+        for chan in chans:
+            if "Phase" in chan:
+                multi_tif_phase = 'img_Phase2D_stabilized.tif'
+                _, phase = cv2.imreadmulti(fullpath + '/' + multi_tif_phase,
+                                           flags=cv2.IMREAD_ANYDEPTH)
+                phase = np.array(phase)
+                shapes.append(phase.shape)
+            if "Retardance" in chan:
+                multi_tif_retard = 'img__Retardance__stabilized.tif'
+                _, ret = cv2.imreadmulti(fullpath + '/' + multi_tif_retard,
+                                         flags=cv2.IMREAD_ANYDEPTH)
+                ret = np.array(ret)
+                shapes.append(ret.shape)
+            if "Brightfield" in chan:
+                multi_tif_bf = 'img_Brightfield_computed_stabilized.tif'
+                _, bf = cv2.imreadmulti(fullpath + '/' + multi_tif_bf,
+                                        flags=cv2.IMREAD_ANYDEPTH)
+                bf = np.array(bf)
+                shapes.append(bf.shape)
 
-    multi_tif_retard = 'img__Retardance__stabilized.tif'
-    multi_tif_phase = 'img_Phase2D_stabilized.tif'
-    multi_tif_bf = 'img_Brightfield_computed_stabilized.tif'
+    # check that all shapes are the same
+    assert shapes.count(shapes[0]) == len(shapes)
 
-    _, ret = cv2.imreadmulti(fullpath + '/' + multi_tif_retard, 
-                             flags=cv2.IMREAD_ANYDEPTH)
-    _, phase = cv2.imreadmulti(fullpath + '/' + multi_tif_phase, 
-                               flags=cv2.IMREAD_ANYDEPTH)
-    _, bf = cv2.imreadmulti(fullpath + '/' + multi_tif_bf, 
-                            flags=cv2.IMREAD_ANYDEPTH)
-    ret = np.array(ret)
-    phase = np.array(phase)
-    bf = np.array(bf)
-
-    assert ret.shape == phase.shape == bf.shape
-
-    n_frame, x_size, y_size = ret.shape[:3]
+    # insert images into a composite array.  Composite always has 3 channels
+    n_frame, x_size, y_size = shapes[0][:3]
     out = np.empty(shape=(n_frame, 3, 1, x_size, y_size))
-    out[:, 0, 0] = phase
-    out[:, 1, 0] = ret
-    out[:, 2, 0] = bf
+    for chan in chans:
+        if "Phase" in chan:
+            out[:, 0, 0] = phase
+        if "Retardance" in chan:
+            out[:, 1, 0] = ret
+        if "Brightfield" in chan:
+            out[:, 2, 0] = bf
 
     return out
 
@@ -89,7 +120,9 @@ def adjust_range(arr):
 
 def write_raw_to_npy(path: str, 
                      site: str, 
-                     output: str, 
+                     output: str,
+                     chans: list,
+                     z_slice: int,
                      multipage: bool = True):
     """Wrapper method for data loading
 
@@ -110,7 +143,7 @@ def write_raw_to_npy(path: str,
     """
 
     output_name = output + '/' + site + '.npy'
-    raw = load_raw(path, site, multipage=multipage)
+    raw = load_raw(path, site, chans, z_slice=z_slice, multipage=multipage)
     raw_adjusted = adjust_range(raw)
     np.save(output_name, raw_adjusted)
     return

--- a/pipeline/preprocess.py
+++ b/pipeline/preprocess.py
@@ -2,8 +2,6 @@
 
 import numpy as np
 import cv2
-import os
-import tifffile as tf
 from typing import Union
 
 

--- a/pipeline/preprocess.py
+++ b/pipeline/preprocess.py
@@ -58,7 +58,7 @@ def load_raw(fullpaths: list,
     shapes = []
 
     if not multipage:
-        log.debug(f"single-page tiffs specified")
+        log.info(f"single-page tiffs specified")
         # load singlepage tiffs.  String parse assuming time series and z### format
         for chan in chans:
             # files maps (key:value) = (z_index, t_y_x array)
@@ -72,7 +72,7 @@ def load_raw(fullpaths: list,
                 log.warning(f"no files with {chan} identified")
                 continue
 
-            # resulting shapes are in (z, t, y, x) order
+            # resulting shapes are in (t, y, x) order
             if "Phase" in chan:
                 phase = np.stack([read_image(f) for f in files])
                 # phase = phase.reshape((len(z_indicies), -1, phase.shape[-2], phase.shape[-1]))
@@ -89,7 +89,7 @@ def load_raw(fullpaths: list,
                 log.warning(f'not implemented: {chan} parse from single page files')
 
     else:
-        print(f"multi-page tiffs specified")
+        log.info(f"multi-page tiffs specified")
         # load stabilized multipage tiffs.
         for chan in chans:
             if "Phase" in chan:
@@ -134,6 +134,8 @@ def load_raw(fullpaths: list,
 
 def adjust_range(arr):
     """Check value range for both channels
+    *** currently does nothing but report mean and std ***
+    *** image z-scoring is done at a later stage ***
 
     To maintain stability, input arrays should be within:
         phase channel: mean - 32767, std - 1600~2000
@@ -175,8 +177,9 @@ def write_raw_to_npy(site: Union[int, str],
 
     Args:
         site: (int or str)
+            name of specific position/site being processed
         site_list (list):
-            list of files for a position/site
+            list of files for this position/site
         output (str):
             path to the output folder
         chans (list):

--- a/pipeline/preprocess.py
+++ b/pipeline/preprocess.py
@@ -3,6 +3,8 @@
 import numpy as np
 import cv2
 from typing import Union
+import logging
+log = logging.getLogger(__name__)
 
 
 def read_image(file_path):
@@ -38,10 +40,11 @@ def load_raw(fullpaths: list,
 
     Args:
         fullpaths (list):
-            path singlepage or multipage tiffs
+            list of full paths to singlepage or multipage tiffs
         chans (list):
             list of strings corresponding to channel names
-        z_slice: (list)
+        z_slice: (int)
+            specific slice to extract if multiple exist
         multipage (bool, optional): default=True
             if folder contains stabilized multipage tiffs
             only multipage tiff is supported now
@@ -55,7 +58,7 @@ def load_raw(fullpaths: list,
     shapes = []
 
     if not multipage:
-        print(f"single-page tiffs specified")
+        log.debug(f"single-page tiffs specified")
         # load singlepage tiffs.  String parse assuming time series and z### format
         for chan in chans:
             # files maps (key:value) = (z_index, t_y_x array)
@@ -63,22 +66,27 @@ def load_raw(fullpaths: list,
             # for z in z_indicies:
             #     files.append([c for c in sorted(os.listdir(fullpath)) if chan in c and f"z{z:03d}" in c])
             # files = np.array(files).flatten()
-            files = [c for c in fullpaths if chan in c and f"z{z_slice:03d}" in c]
+            files = [c for c in fullpaths if chan in c.split('/')[-1] and f"z{z_slice:03d}" in c.split('/')[-1]]
             files = sorted(files)
+            if not files:
+                log.warning(f"no files with {chan} identified")
+                continue
 
             # resulting shapes are in (z, t, y, x) order
             if "Phase" in chan:
                 phase = np.stack([read_image(f) for f in files])
                 # phase = phase.reshape((len(z_indicies), -1, phase.shape[-2], phase.shape[-1]))
                 shapes.append(phase.shape)
-            if "Retardance" in chan:
+            elif "Retardance" in chan:
                 ret = np.stack([read_image(f) for f in files])
                 # ret = ret.reshape((len(z_indicies), -1, ret.shape[-2], ret.shape[-1]))
                 shapes.append(ret.shape)
-            if "Brightfield" in chan:
+            elif "Brightfield" in chan:
                 bf = np.stack([read_image(f) for f in files])
                 # bf = bf.reshape((len(z_indicies), -1, bf.shape[-2], bf.shape[-1]))
                 shapes.append(bf.shape)
+            else:
+                log.warning(f'not implemented: {chan} parse from single page files')
 
     else:
         print(f"multi-page tiffs specified")
@@ -109,14 +117,17 @@ def load_raw(fullpaths: list,
     # insert images into a composite array.  Composite always has 3 channels
     n_frame, x_size, y_size = shapes[0][:3]
     out = np.empty(shape=(n_frame, 3, 1, x_size, y_size))
-    print(f"writing channels ({chans}) to composite array")
+    log.info(f"writing channels ({chans}) to composite array")
     for chan in chans:
-        if "Phase" in chan:
-            out[:, 0, 0] = phase
-        if "Retardance" in chan:
-            out[:, 1, 0] = ret
-        if "Brightfield" in chan:
-            out[:, 2, 0] = bf
+        try:
+            if "Phase" in chan:
+                out[:, 0, 0] = phase
+            if "Retardance" in chan:
+                out[:, 1, 0] = ret
+            if "Brightfield" in chan:
+                out[:, 2, 0] = bf
+        except UnboundLocalError:
+            log.warning('variable referenced before assignment')
 
     return out
 
@@ -136,7 +147,7 @@ def adjust_range(arr):
         np.array: numpy array with value range adjusted
 
     """
-    print(f"z scoring data")
+    log.info(f"z scoring data")
 
     mean_c0 = arr[:, 0, 0].mean()
     mean_c1 = arr[:, 1, 0].mean()
@@ -144,9 +155,9 @@ def adjust_range(arr):
     std_c0 = arr[:, 0, 0].std()
     std_c1 = arr[:, 1, 0].std()
     std_c2 = arr[:, 2, 0].std()
-    print("\tPhase: %d plus/minus %d" % (mean_c0, std_c0))
-    print("\tRetardance: %d plus/minus %d" % (mean_c1, std_c1))
-    print("\tBrightfield: %d plus/minus %d" % (mean_c2, std_c2))
+    log.info("\tPhase: %d plus/minus %d" % (mean_c0, std_c0))
+    log.info("\tRetardance: %d plus/minus %d" % (mean_c1, std_c1))
+    log.info("\tBrightfield: %d plus/minus %d" % (mean_c2, std_c2))
     #TODO: manually adjust range if input doesn't satisfy
     return arr
 
@@ -181,7 +192,7 @@ def write_raw_to_npy(site: Union[int, str],
     raw = load_raw(site_list, chans, z_slice=z_slice, multipage=multipage)
     raw_adjusted = adjust_range(raw)
 
-    output_name = output + '/' + site + '.npy'
-    print(f"saving image stack to {output_name}")
+    output_name = output + '/' + str(site) + '.npy'
+    log.info(f"saving image stack to {output_name}")
     np.save(output_name, raw_adjusted)
     return

--- a/pipeline/preprocess.py
+++ b/pipeline/preprocess.py
@@ -5,7 +5,6 @@ import cv2
 import os
 import tifffile as tf
 
-
 def load_raw(path: str, 
              site: str,
              chans: list,
@@ -36,6 +35,7 @@ def load_raw(path: str,
     shapes = []
 
     if not multipage:
+        print(f"single-page tiffs specified")
         # load singlepage tiffs.  String parse assuming time series and z### format
         for chan in chans:
             files = [c for c in os.listdir(fullpath) if chan in c and f"z{z_slice:03d}" in c]
@@ -51,6 +51,7 @@ def load_raw(path: str,
                 shapes.append(bf.shape)
 
     else:
+        print(f"multi-page tiffs specified")
         # load stabilized multipage tiffs.
         for chan in chans:
             if "Phase" in chan:
@@ -78,6 +79,7 @@ def load_raw(path: str,
     # insert images into a composite array.  Composite always has 3 channels
     n_frame, x_size, y_size = shapes[0][:3]
     out = np.empty(shape=(n_frame, 3, 1, x_size, y_size))
+    print(f"writing channels ({chans}) to composite array")
     for chan in chans:
         if "Phase" in chan:
             out[:, 0, 0] = phase
@@ -104,6 +106,7 @@ def adjust_range(arr):
         np.array: numpy array with value range adjusted
 
     """
+    print(f"z scoring data")
 
     mean_c0 = arr[:, 0, 0].mean()
     mean_c1 = arr[:, 1, 0].mean()
@@ -145,5 +148,6 @@ def write_raw_to_npy(path: str,
     output_name = output + '/' + site + '.npy'
     raw = load_raw(path, site, chans, z_slice=z_slice, multipage=multipage)
     raw_adjusted = adjust_range(raw)
+    print(f"saving image stack to {output_name}")
     np.save(output_name, raw_adjusted)
     return

--- a/requirements/defaults.txt
+++ b/requirements/defaults.txt
@@ -6,6 +6,7 @@ scikit-image>=0.16
 scikit-learn>0.20.0
 tifffile>=0.15.1
 imageio>=2.6.0
+imagecodecs>=2020.5.30
 POT>=0.6.0
 h5py>=2.10.0
 tensorflow>=1.13

--- a/requirements/defaults.txt
+++ b/requirements/defaults.txt
@@ -6,7 +6,6 @@ scikit-image>=0.16
 scikit-learn>0.20.0
 tifffile>=0.15.1
 imageio>=2.6.0
-imagecodecs>=2020.5.30
 POT>=0.6.0
 h5py>=2.10.0
 tensorflow>=1.13

--- a/run_preproc.py
+++ b/run_preproc.py
@@ -17,6 +17,17 @@ log = logging.getLogger(__name__)
 
 
 def main(input_, output_, config_):
+    """
+    Using supplied config file parameters, prepare specified datasets for downstream analysis
+
+    :param input_: str
+        Path to a single experiment
+    :param output_: str
+        Path to output directory for prepared datasets
+    :param config_: YamlReader
+        YamlReader object containing parsed configuration values
+    :return:
+    """
 
     chans = config_.preprocess.channels
     multi = config_.preprocess.multipage
@@ -57,8 +68,6 @@ def main(input_, output_, config_):
 
         elif type(fovs) is list:
             for fov in fovs:
-                # regex = re.compile()
-                # sites[fov] = [os.path.join(input_, f) for f in sorted(fnmatch.filter(all_files, f'*p{fov:03d}*'))]
                 sites[fov] = [os.path.join(input_, f) for f in sorted(fnmatch.filter(all_files, f'*p{fov:03d}*'))]
         else:
             raise NotImplementedError("FOV index expected, or preprocess FOVs must be 'all' or list of positions")
@@ -91,19 +100,6 @@ def parse_args():
     :return: namespace containing the arguments passed.
     """
     parser = argparse.ArgumentParser()
-
-    # parser.add_argument(
-    #     '-i', '--input',
-    #     type=str,
-    #     required=False,
-    #     help="Path to multipage-tiff file of format [t, x, y], or to single-page-tiffs",
-    # )
-    # parser.add_argument(
-    #     '-o', '--output',
-    #     type=str,
-    #     required=False,
-    #     help="Path to write results",
-    # )
     parser.add_argument(
         '-c', '--config',
         type=str,
@@ -115,13 +111,10 @@ def parse_args():
 
 
 if __name__ == '__main__':
-    # print(time.asctime(time.localtime(time.time())), flush=True)
     arguments = parse_args()
     config = YamlReader()
     config.read_config(arguments.config)
 
     for (src, target) in list(zip(config.preprocess.image_dirs, config.preprocess.target_dirs)):
         main(src, target, config)
-
-    # print(time.asctime(time.localtime(time.time())), flush=True)
 

--- a/run_preproc.py
+++ b/run_preproc.py
@@ -1,4 +1,3 @@
-# bchhun, {2020-02-21}
 
 # 1. check input: (n_frames * 2048 * 2048 * 2) channel 0 - phase, channel 1 - retardance
 # 2. adjust channel range
@@ -9,9 +8,12 @@
 from pipeline.preprocess import write_raw_to_npy
 import os
 import fnmatch
+import re
 
 import argparse
 from configs.config_reader import YamlReader
+import logging
+log = logging.getLogger(__name__)
 
 
 def main(input_, output_, config_):
@@ -21,11 +23,12 @@ def main(input_, output_, config_):
     z_slice = config_.preprocess.z_slice
     fovs = config_.preprocess.fov
 
-    # build list of all sites we wish to process
+    # === build list or dict of all sites we wish to process ===
 
     # positions are identified by subfolder names
     if config_.preprocess.pos_dir:
-        if fovs is 'all':
+        log.info("pos dir, identifying all subfolders")
+        if fovs == 'all':
             sites = [site for site in os.listdir(input_) if os.path.isdir(os.path.join(input_, site))]
         elif type(fovs) is list:
             sites = [site for site in os.listdir(input_) if os.path.isdir(os.path.join(input_, site)) and site in fovs]
@@ -35,43 +38,47 @@ def main(input_, output_, config_):
     # positions are identified by indicies
     # assume files have name structure "t###_p###_z###"
     elif not config_.preprocess.pos_dir:
+        log.info("no pos dir, identifiying all files")
         sites = {}
         all_files = [f for f in os.listdir(input_)
                      if os.path.isfile(os.path.join(input_, f)) and '_p' in f and '.tif' in f]
 
-        if fovs is 'all':
+        if fovs == 'all':
+            log.info("fovs = all, looping ")
             # for every position index in the file, assign the image to a dict key
             while all_files:
                 pos = [int(p_idx.strip('p')) for p_idx in all_files[0].split('_') if 'p' in p_idx][0]
                 if not pos:
                     all_files.pop(0)
                 if pos in sites.keys():
-                    sites[pos].append(all_files.pop(0))
+                    sites[pos].append(os.path.join(input_, all_files.pop(0)))
                 else:
-                    sites[pos] = [all_files.pop(0)]
+                    sites[pos] = [os.path.join(input_, all_files.pop(0))]
 
         elif type(fovs) is list:
             for fov in fovs:
-                sites[fov] = fnmatch.filter(all_files, f'*p{fov:03d}*')
+                # regex = re.compile()
+                # sites[fov] = [os.path.join(input_, f) for f in sorted(fnmatch.filter(all_files, f'*p{fov:03d}*'))]
+                sites[fov] = [os.path.join(input_, f) for f in sorted(fnmatch.filter(all_files, f'*p{fov:03d}*'))]
         else:
             raise NotImplementedError("FOV index expected, or preprocess FOVs must be 'all' or list of positions")
     else:
         raise NotImplementedError("pos_dir must be boolean True/False")
 
     # write sites
-    for site in sites:
+    for site in sorted(sites):
         if not os.path.exists(output_):
             os.makedirs(output_)
 
-        # site represents a folder path
+        # site represents a position folder
         if type(site) is str:
-            s_list = [os.path.join(input_, f) for f in sorted(os.listdir(site))]
+            s_list = [os.path.join(input_, site, f) for f in sorted(os.listdir(os.path.join(input_, site)))]
 
-        # site represents a list of files filtered by position index
-        elif type(site) is list:
-            s_list = site
+        # site represents a position index
+        elif type(site) is int:
+            s_list = sites[site]
         else:
-            print(f"no files found for {site}")
+            log.warning(f"no files found for position = {site}")
             continue
 
         write_raw_to_npy(site, s_list, output_, chans, z_slice, multipage=multi)

--- a/run_preproc.py
+++ b/run_preproc.py
@@ -8,6 +8,7 @@
 
 from pipeline.preprocess import write_raw_to_npy
 import os
+import fnmatch
 
 import argparse
 from configs.config_reader import YamlReader
@@ -18,22 +19,62 @@ def main(input_, output_, config_):
     chans = config_.preprocess.channels
     multi = config_.preprocess.multipage
     z_slice = config_.preprocess.z_slice
+    fovs = config_.preprocess.fov
 
-    if config_.preprocess.fov:
-        sites = config_.preprocess.fov
+    # build list of all sites we wish to process
+
+    # positions are identified by subfolder names
+    if config_.preprocess.pos_dir:
+        if fovs is 'all':
+            sites = [site for site in os.listdir(input_) if os.path.isdir(os.path.join(input_, site))]
+        elif type(fovs) is list:
+            sites = [site for site in os.listdir(input_) if os.path.isdir(os.path.join(input_, site)) and site in fovs]
+        else:
+            raise NotImplementedError("FOV subfolder expected, or preprocess FOVs must be 'all' or list of positions")
+
+    # positions are identified by indicies
+    # assume files have name structure "t###_p###_z###"
+    elif not config_.preprocess.pos_dir:
+        sites = {}
+        all_files = [f for f in os.listdir(input_)
+                     if os.path.isfile(os.path.join(input_, f)) and '_p' in f and '.tif' in f]
+
+        if fovs is 'all':
+            # for every position index in the file, assign the image to a dict key
+            while all_files:
+                pos = [int(p_idx.strip('p')) for p_idx in all_files[0].split('_') if 'p' in p_idx][0]
+                if not pos:
+                    all_files.pop(0)
+                if pos in sites.keys():
+                    sites[pos].append(all_files.pop(0))
+                else:
+                    sites[pos] = [all_files.pop(0)]
+
+        elif type(fovs) is list:
+            for fov in fovs:
+                sites[fov] = fnmatch.filter(all_files, f'*p{fov:03d}*')
+        else:
+            raise NotImplementedError("FOV index expected, or preprocess FOVs must be 'all' or list of positions")
     else:
-        # assume all subdirectories are site/FOVs
-        sites = [site for site in os.listdir(input_) if os.path.isdir(os.path.join(input_, site))]
+        raise NotImplementedError("pos_dir must be boolean True/False")
 
+    # write sites
     for site in sites:
         if not os.path.exists(output_):
             os.makedirs(output_)
 
-        try:
-            print(f"writing {site} to {output_}", flush=True)
-            write_raw_to_npy(input_, site, output_, chans, multipage=multi, z_slice=z_slice)
-        except Exception as e:
-            print(f"\terror in writing {site}", flush=True)
+        # site represents a folder path
+        if type(site) is str:
+            s_list = [os.path.join(input_, f) for f in sorted(os.listdir(site))]
+
+        # site represents a list of files filtered by position index
+        elif type(site) is list:
+            s_list = site
+        else:
+            print(f"no files found for {site}")
+            continue
+
+        write_raw_to_npy(site, s_list, output_, chans, z_slice, multipage=multi)
 
 
 def parse_args():
@@ -44,18 +85,18 @@ def parse_args():
     """
     parser = argparse.ArgumentParser()
 
-    parser.add_argument(
-        '-i', '--input',
-        type=str,
-        required=True,
-        help="Path to multipage-tiff file of format [t, x, y], or to single-page-tiffs",
-    )
-    parser.add_argument(
-        '-o', '--output',
-        type=str,
-        required=True,
-        help="Path to write results",
-    )
+    # parser.add_argument(
+    #     '-i', '--input',
+    #     type=str,
+    #     required=False,
+    #     help="Path to multipage-tiff file of format [t, x, y], or to single-page-tiffs",
+    # )
+    # parser.add_argument(
+    #     '-o', '--output',
+    #     type=str,
+    #     required=False,
+    #     help="Path to write results",
+    # )
     parser.add_argument(
         '-c', '--config',
         type=str,
@@ -72,7 +113,8 @@ if __name__ == '__main__':
     config = YamlReader()
     config.read_config(arguments.config)
 
-    main(arguments.input, arguments.output, config)
+    for (src, target) in list(zip(config.preprocess.image_dirs, config.preprocess.target_dirs)):
+        main(src, target, config)
 
     # print(time.asctime(time.localtime(time.time())), flush=True)
 


### PR DESCRIPTION
Introduce a CLI for preprocessing steps.

This PR also enables preprocessing of single-page tiff datasets.  It sorts and then filters z-slices based on string parsing.

This is tested on the small dataset here:
`/gpfs/CompMicro/projects/dynamorph/microglia/subset_for_tests/mg_small/JUNE/tiffs`
and the output written here:
`/gpfs/CompMicro/projects/dynamorph/microglia/subset_for_tests/mg_small/JUNE/tiffs`

Resulting "composite" .npy arrays are 3-channels with Phase, Retardance, BF in channels index position 0, 1, 2, respectively.

@miaecle @smguo @mattersoflight 