### PR TITLE
Support for flat data structure

### DIFF
--- a/configs/config_example.yml
+++ b/configs/config_example.yml
@@ -21,6 +21,7 @@ preprocess:
   fov: ['C5-Site_0','C5-Site_1']
   multipage: False
   z_slice: 2
+  pos_dir: True   # "True" if images from each position are saved in separate directories
 
 
 patch:

--- a/configs/config_example.yml
+++ b/configs/config_example.yml
@@ -18,7 +18,7 @@ files:
 
 preprocess:
   channels: ["Retardance", "Phase2D", "Brightfield"]
-  fov: ['C5-Site_0','C5-Site_1']
+  fov: ['C5-Site_0','C5-Site_1']    # positions to process. Put 'all' to process all available positions
   multipage: False
   z_slice: 2
   pos_dir: True   # "True" if images from each position are saved in separate directories

--- a/configs/config_reader.py
+++ b/configs/config_reader.py
@@ -21,6 +21,7 @@ FILES = {
 PREPROCESS = {
     'channels',
     'fov',
+    'pos_dir',
     'multipage',
     'z_slice'
 }

--- a/pipeline/preprocess.py
+++ b/pipeline/preprocess.py
@@ -3,7 +3,6 @@
 import numpy as np
 import cv2
 import os
-import tifffile as tf
 
 def read_image(file_path):
     """

--- a/pipeline/preprocess.py
+++ b/pipeline/preprocess.py
@@ -59,10 +59,12 @@ def load_raw(path: str,
         # load singlepage tiffs.  String parse assuming time series and z### format
         if pos_dir:
             fullpath = os.path.join(path, site)
+            fname_pos = ""
         else:
             fullpath = path
+            fname_pos = site
         for chan in chans:
-            files = [c for c in os.listdir(fullpath) if chan in c and f"z{z_slice:03d}" in c]
+            files = [c for c in os.listdir(fullpath) if chan in c and f"z{z_slice:03d}" in c and fname_pos in c]
             files = sorted(files)
             if "Phase" in chan:
                 phase = np.stack([read_image(os.path.join(fullpath, f)) for f in files])

--- a/requirements/defaults.txt
+++ b/requirements/defaults.txt
@@ -6,7 +6,6 @@ scikit-image>=0.16
 scikit-learn>0.20.0
 tifffile>=0.15.1
 imageio>=2.6.0
-imagecodecs>=2020.5.30
 POT>=0.6.0
 h5py>=2.10.0
 tensorflow>=1.13


### PR DESCRIPTION
This PR adds support for flat data structure (images from all positions are saved in one directory) to `run_preproc.py`. Also tifffile is replaced by opencv to read single page tiff because dependency issues with imagecodecs.   